### PR TITLE
Fix README terminal search order

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Leave blank to honour `[colors]`.
 program = alacritty
 ```
 
-If empty, `$TERMINAL` env or a fallback list (`kitty`, `wezterm`, `xterm`…) is used.
+If left blank, the launcher checks `$TERMINAL` first then falls back to
+`kitty`, `alacritty`, `wezterm`, `foot`, `gnome-terminal`, `konsole`,
+`xfce4-terminal` and finally `xterm`.
 
 </details>
 


### PR DESCRIPTION
## Summary
- clarify how nLauncher selects a terminal

## Testing
- `nimble test -y` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ea5191b08328b25ae5ff65fb5f53