### PR TITLE
Fix nimble lint path

### DIFF
--- a/nLauncher.nimble
+++ b/nLauncher.nimble
@@ -14,4 +14,4 @@ bin = @["nLauncher"]
 # Custom tasks are still great for things like linting.
 task lint, "Lint all *.nim files":
   # A more precise glob pattern for your source files
-  exec "nimpretty --indent:2 --maxLineLen:106 scr/**/*.nim"
+  exec "nimpretty --indent:2 --maxLineLen:106 src/**/*.nim"


### PR DESCRIPTION
## Summary
- fix the lint task path in `nLauncher.nimble`

## Testing
- `apt-get update` *(fails: repository signature errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888ea104ae483289a56cbbc3b969e3f