### PR TITLE
Fix config path quoting

### DIFF
--- a/src/nLauncher.nim
+++ b/src/nLauncher.nim
@@ -43,7 +43,7 @@ proc scanConfigFiles*(query: string): seq[DesktopApp] =
     if fileExists(path) and path.extractFilename.toLower.contains(query.toLower):
       result.add DesktopApp(
         name:     path.extractFilename,
-        exec:     "xdg-open '" & path & "'",
+        exec:     "xdg-open " & shellQuote(path),
         hasIcon:  false
       )
 

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -13,6 +13,16 @@ import std/[os, strutils, times, json, math]
 import x11/[xlib, x, xft, xrender]
 import state           # display*, screen*, config, fallbackTerms, recentApps
 
+## Quote *s* for safe use inside a shell command.
+proc shellQuote*(s: string): string =
+  result = "'"
+  for ch in s:
+    if ch == '\'':
+      result.add("'\\''")
+    else:
+      result.add(ch)
+  result.add("'")
+
 # ── Executable discovery ────────────────────────────────────────────────
 ## Returns true if an executable *name* can be found in $PATH.
 proc whichExists*(name: string): bool =
@@ -30,7 +40,7 @@ proc chooseTerminal*(): string =
     return config.terminalExe
 
   # 2) otherwise, pick from known list
-  for t in @["kitty", "alacritty", "gnome-terminal", "xterm", "urxvt"]:
+  for t in fallbackTerms:
     if whichExists(t):
       echo "DEBUG ▶ chooseTerminal: falling back to '", t, "'"
       return t


### PR DESCRIPTION
## Summary
- escape single quotes so config search works for files with `'` in the name
- reuse fallback terminal list from `state`

## Testing
- `nimble build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e8270ad48328b704397d5c574112