### PR TITLE
refactor: deduplicate shell arg appending

### DIFF
--- a/src/nlauncher.nim
+++ b/src/nlauncher.nim
@@ -25,19 +25,24 @@ proc hasHoldFlagLocal(args: seq[string]): bool =
       discard
   false
 
+proc appendShellArgs(argv: var seq[string]; shExe: string; shArgs: seq[string]) =
+  ## Append shell executable and its arguments to `argv`.
+  argv.add shExe
+  for a in shArgs:
+    argv.add a
+
 proc buildTerminalArgs(base: string; termArgs: seq[string]; shExe: string;
     shArgs: seq[string]): seq[string] =
   ## Normalize command-line to launch a shell inside major terminals.
   var argv = termArgs
   case base
   of "gnome-terminal", "kgx":
-    argv.add "--"; argv.add shExe; for a in shArgs: argv.add a
+    argv.add "--"
   of "wezterm":
-    argv = @["start"] & argv; argv.add shExe; for a in shArgs: argv.add a
-  of "kitty":
-    argv.add "-e"; argv.add shExe; for a in shArgs: argv.add a
+    argv = @["start"] & argv
   else:
-    argv.add "-e"; argv.add shExe; for a in shArgs: argv.add a
+    argv.add "-e"
+  appendShellArgs(argv, shExe, shArgs)
   argv
 
 proc buildShellCommand(cmd, shExe: string; hold = false):


### PR DESCRIPTION
## Summary
- create helper `appendShellArgs` for reusing shell argument appending
- simplify `buildTerminalArgs` to use helper and remove repeated code

## Testing
- `nim c -r src/nlauncher.nim` *(fails: command not found)*
- `apt-get update` *(fails: repository 403, could not install nim)*

------
https://chatgpt.com/codex/tasks/task_e_689749c2230883289fc672c2c18c9113