### PR TITLE
Switch web and config commands to colon prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 | **Live theme cycling & persistence** | Press F5 to cycle themes; saves your last choice in the TOML config                                               |
 | **Theme preview mode**               | `/t` shows a lightweight preview list of available themes                                                         |
 | **Fully themable via TOML**          | 25+ colour schemes built-in; add your own under `[[themes]]` in `nlauncher.toml`                                  |
-| **Slash triggers**                   | `/ …` run shell command • `/c …` open dotfile • `/y …` YouTube • `/g …` Google • `/w …` Wiki • `/t` Theme preview |
+| **Prefix triggers**                   | `/ …` run shell command • `c: …` open dotfile • `y: …` YouTube • `g: …` Google • `w: …` Wiki • `/t` Theme preview |
 | **Zero toolkit**                     | Pure Xlib + Xft + [parsetoml](https://github.com/pragmagic/parsetoml)                                             |
 
 ---
@@ -63,10 +63,10 @@ nimble release   # produces ./bin/nlauncher
 | --------------------- | ---------------------------------------------------------------------- |
 | *Type letters*        | Instant fuzzy filter (typo-tolerant)                                   |
 | `/ …`                 | Run shell command (everything after the slash is passed to your shell) |
-| `/c …`                | Search `~/.config` for dotfiles and open in your editor                |
-| `/y …`                | Search YouTube in browser                                              |
-| `/g …`                | Google search in browser                                               |
-| `/w …`                | Wikipedia search in browser                                            |
+| `c: …`                | Search `~/.config` for dotfiles and open in your editor                |
+| `y: …`                | Search YouTube in browser                                              |
+| `g: …`                | Google search in browser                                               |
+| `w: …`                | Wikipedia search in browser                                            |
 | `/t`                  | Preview available themes in a quick selection list                     |
 | **Enter**             | Launch item / run command                                              |
 | **Esc**               | Quit                                                                   |

--- a/src/state.nim
+++ b/src/state.nim
@@ -53,10 +53,10 @@ type
   ActionKind* = enum
     akApp,     # a real .desktop application
     akRun,     # a `/…` shell command
-    akConfig,  # `/c` file under ~/.config
-    akYouTube, # `/y` YouTube search
-    akGoogle,  # `/g` Google search
-    akWiki,     # `/w` Wiki search
+    akConfig,  # `c:` file under ~/.config
+    akYouTube, # `y:` YouTube search
+    akGoogle,  # `g:` Google search
+    akWiki,     # `w:` Wiki search
     akTheme    # `/t` Theme selector
 
   ## A single selectable entry in the launcher.


### PR DESCRIPTION
## Summary
- Support `y:`, `g:`, and `w:` web shortcuts and `c:` for config search
- Replace slash-only parser with generic `parseCommand` and `CmdKind`
- Document new colon prefixes in README and state comments

## Testing
- `nimble build -y` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68975c4c15ec83288367269e69a027a4