### PR TITLE
Use t: prefix for theme selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 | **Recent-apps history**              | Empty query shows your last launches first                                                                        |
 | **100% keyboard-driven**             | Arrow keys / PageUp / PageDown / Home / End / Left / Right / Enter / Esc                                          |
 | **Live theme cycling & persistence** | Press F5 to cycle themes; saves your last choice in the TOML config                                               |
-| **Theme preview mode**               | `/t` shows a lightweight preview list of available themes                                                         |
+| **Theme preview mode**               | `t:` shows a lightweight preview list of available themes                                                         |
 | **Fully themable via TOML**          | 25+ colour schemes built-in; add your own under `[[themes]]` in `nlauncher.toml`                                  |
-| **Slash triggers**                   | `/ …` run shell command • `/c …` open dotfile • `/y …` YouTube • `/g …` Google • `/w …` Wiki • `/t` Theme preview |
+| **Slash triggers**                   | `/ …` run shell command • `/c …` open dotfile • `/y …` YouTube • `/g …` Google • `/w …` Wiki • `t:` Theme preview |
 | **Zero toolkit**                     | Pure Xlib + Xft + [parsetoml](https://github.com/pragmagic/parsetoml)                                             |
 
 ---
@@ -67,7 +67,7 @@ nimble release   # produces ./bin/nlauncher
 | `/y …`                | Search YouTube in browser                                              |
 | `/g …`                | Google search in browser                                               |
 | `/w …`                | Wikipedia search in browser                                            |
-| `/t`                  | Preview available themes in a quick selection list                     |
+| `t:`                  | Preview available themes in a quick selection list                     |
 | **Enter**             | Launch item / run command                                              |
 | **Esc**               | Quit                                                                   |
 | **↑ / ↓**             | Navigate list                                                          |

--- a/src/nlauncher.nim
+++ b/src/nlauncher.nim
@@ -387,9 +387,9 @@ const webSpecs: array[3, WebSpec] = [
 ]
 
 type SlashKind = enum
-  ## Recognised `/`-prefix commands.
-  skNone,        # not a slash command
-  skTheme,       # `/t`
+  ## Recognised command prefixes.
+  skNone,        # not a command prefix
+  skTheme,       # `t:`
   skConfig,      # `/c`
   skWeb,         # `/y`, `/g`, `/w`
   skRun          # raw `/` command
@@ -397,12 +397,14 @@ type SlashKind = enum
 proc parseSlashCommand(inputText: string): (SlashKind, string, int) =
   ## Parse *inputText* and return the command kind, remainder, and web spec index.
   ## The index is `-1` unless `kind` is `skWeb`.
+  var rest: string
+
+  if takePrefix(inputText, "t:", rest):
+    return (skTheme, rest, -1)
+
   if not inputText.startsWith("/"):
     return (skNone, inputText, -1)
 
-  var rest: string
-  if takePrefix(inputText, "/t", rest):
-    return (skTheme, rest, -1)
   if takePrefix(inputText, "/c", rest):
     return (skConfig, rest, -1)
   for i, spec in webSpecs:

--- a/src/state.nim
+++ b/src/state.nim
@@ -57,7 +57,7 @@ type
     akYouTube, # `/y` YouTube search
     akGoogle,  # `/g` Google search
     akWiki,     # `/w` Wiki search
-    akTheme    # `/t` Theme selector
+    akTheme    # `t:` Theme selector
 
   ## A single selectable entry in the launcher.
   Action* = object
@@ -143,7 +143,7 @@ width = 2                         # Border thickness in pixels (0 = no border)
 # Themes
 # ==========================
 # Add or remove [[themes]] blocks to customize appearance.
-# The "name" field is what you'll see in the theme selector (/t or F5).
+# The "name" field is what you'll see in the theme selector (t: or F5).
 # Colors:
 #   bgColorHex          = Window background
 #   fgColorHex          = Normal text color
@@ -152,7 +152,7 @@ width = 2                         # Border thickness in pixels (0 = no border)
 #   borderColorHex      = Window border color
 #   matchFgColorHex     = Color for matching characters in search results
 #
-# Tip: You can quickly preview themes in-app with the `/t` command.
+# Tip: You can quickly preview themes in-app with the `t:` command.
 
 [[themes]]
 name                = "Arstotzka"   


### PR DESCRIPTION
## Summary
- accept `t:` prefix to switch themes
- refresh docs and comments to reference `t:` instead of `/t`

## Testing
- `nimble build -y` *(fails: command not found)*
- `apt-get update` *(fails: repository 403; unable to install nim)*

------
https://chatgpt.com/codex/tasks/task_e_68975c51d5608328a494a0a836100fbd